### PR TITLE
Fix wrong redirects

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,8 +29,8 @@
                         <h3>Study Materials</h3>
                         <ul>
                             <li><a href="https://gcect.ac.in/question-paper-download/">PYQs</a></li>
-                            <li><a href="discord.gg/SJCKgufQad">Assignments</a></li>
-                            <li><a href="discord.gg/SJCKgufQad">Solutions</a></li>
+                            <li><a href="https://discord.gg/SJCKgufQad">Assignments</a></li>
+                            <li><a href="https://discord.gg/SJCKgufQad">Solutions</a></li>
                         </ul>
                     </section>
                 </td>


### PR DESCRIPTION
Without the HTTP protocol, browser searches for the href url under the main subdomain